### PR TITLE
Update snappymodule.cc

### DIFF
--- a/snappymodule.cc
+++ b/snappymodule.cc
@@ -68,7 +68,7 @@ maybe_resize(PyObject *str, size_t expected_size, size_t actual_size)
 	        _PyBytes_Resize(&str, actual_size);
 	        return str;
 	    }
-	    Py_SIZE(str) = actual_size;
+	    Py_SET_SIZE(str, actual_size);
     }
     return str;
 }


### PR DESCRIPTION
clang needed this change to build and reflects line 72 of the upstream python-snappy

Using an ARM-based MacOS system and python 3.11, aff4-snappy would fail building wheel. Looking at the upstream python-snappy and comparing, I have identified the upstream line 72 in snappymodule.cc "Py_SET_SIZE(str, actual_size);" as a possible patch to address line 71 in aff4-snappy's snappymodule.cc "Py_SIZE(str) = actual_size;" of which build was failing on. referencing comparison: https://github.com/aff4/aff4-snappy/compare/master...andrix:python-snappy:master